### PR TITLE
Remove no-longer-needed dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,2 @@
-autopep8==1.5.5
-bandit==1.7.0
-black==20.8b1
-flake8==3.8.4
 Markdown==3.3.4
 pelican==4.5.4
-pydocstyle==5.1.1
-pylint==2.7.2
-safety==1.10.3


### PR DESCRIPTION
After moving to GH actions using Cytopia's Docker images
for the various linting tools, I no longer need them
in this image. See:

https://github.com/pzelnip/www.codependentcodr.com/pull/206
https://github.com/pzelnip/www.codependentcodr.com/pull/207

In fact, I think if I can find a Pelican image, I can
deprecate this repo entirely.